### PR TITLE
Separate out sexual and romantic orientations and expand.

### DIFF
--- a/sexualorientation.md
+++ b/sexualorientation.md
@@ -1,14 +1,56 @@
 ### Sexual Orientation
 
-    Do you identify with any of the following?
-    [] Asexual
-    [] Bisexual
-    [] Gay
-    [] Lesbian
-    [] Queer
+    What is your sexual orientation (check all that apply)?
     [] Straight
+    [] Questioning
+    [] Gay
+    [] Masexual/androsexual
+    [] Lesbian
+    [] Womasexual/gynesexual
+    [] Queer
+    [] Poly
+    [] Asexual
+    [] Graysexual
+    [] Demisexual
+    [] Bisexual
+    [] Bicurious
+    [] Trisexual
+    [] Pansexual
+    [] Omnisexual
+    [] Fluid/abrosexual
+    [] Aceflux
+    [] Autosexual
+    [] Androgynesexual
+    [] Self Identify: _________________
+    [] Prefer not to answer
+
+    What is your romantic orientation (check all that apply)?
+    [] Straight
+    [] Questioning
+    [] Gay
+    [] Manromantic/androromantic
+    [] Lesbian
+    [] Womanromantic/gyneromantic
+    [] Queer
+    [] Poly
+    [] Aromantic
+    [] Grayromantic
+    [] Demiromantic
+    [] Biromantic
+    [] Bicurious
+    [] Triromantic
+    [] Panromatic
+    [] Omniromantic
+    [] Fluid/abroromantic
+    [] Aroflux
+    [] Autoromantic
+    [] Androgyneromantic
     [] Self Identify: _________________
     [] Prefer not to answer
 
 ### Rationale
-Note that these are checkboxes and not radio buttons.  Many people who identify as queer may also identify as something else. 
+Note that these are checkboxes and not radio buttons.  Many people who identify as queer may also identify as something else.
+
+We separate out the questions of sexual and romantic attraction because people can have different identities for both.
+
+The list of sexual and romantic identities was taken from the book "The ABCs of LGBTQ+" by Ashley Mardell. Available at https://mango.bz/books/the-abcs-of-lgbt-by-ashley-mardell-113-b


### PR DESCRIPTION
It's important to separate out sexual and romantic identities to ensure
people's LGBTQ identities don't get erased. For example, a person who
doesn't experience sexual attraction may still want a romantic
relationship with a person of any gender, and are thus both asexual and
panromantic.

Terms like "womasexual" or "androromantic" are alternative terms for
"lesbian" and "gay". Those terms are often tied to gender identity, i.e.
lesbian means "a woman who is attracted to women". A person who is
agender, non-binary, or genderfluid may not identify as a woman or may
identify as both a man and a woman. The prefixes "woma/gyne" and
"ma/andro" separate sexual attraction from gender identity.

All terms again come from the book "The ABC's of LGBTQ+" by Ashley
Mardell.