### PR TITLE
Adding and normalizing Self Identify as an option

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -8,3 +8,5 @@ Contributors (and their reasons for contributing)
 @paulsheldrake
 @rootwork
 @sarahsharp, I support diversity in open source and moving towards more inclusive communities.
+@bronwynlewis, I'm passionate about how people can build empathy for others which starts with awareness of people's existence and intersectional identity
+

--- a/disability.md
+++ b/disability.md
@@ -6,7 +6,7 @@
     [] Yes, Mental
     [] Yes, Physical
     [] Yes, Visual
-    [] Yes, Other
+    [] Yes, Self Identify: _________________
     [] No
     [] Prefer not to answer
 

--- a/gender.md
+++ b/gender.md
@@ -43,7 +43,7 @@
     [] Androgynous
     [] Androgyne
     [] Prefer not to answer
-    [___________] Self-identify
+    [] Self Identify: _________________
 
 
 ### Rationale

--- a/race.md
+++ b/race.md
@@ -10,7 +10,7 @@
     [] Native American
     [] Pacific Islander
     [] White
-    [] Other
+    [] Self Identify: _________________
     [] Prefer not to answer
 
 ### Rationale


### PR DESCRIPTION
I added and updated to use the same **Self Identify** open-ended question option as sexualorientation.md instead of **Other**. This is done to be more inclusive and resist "othering" or forcing folks to pick options that are not representative of themselves.